### PR TITLE
Demonstrate a bug with the output matcher.

### DIFF
--- a/spec/rspec/matchers/built_in/output_spec.rb
+++ b/spec/rspec/matchers/built_in/output_spec.rb
@@ -144,6 +144,13 @@ module RSpec
           $stderr.print(msg)
         end
       }
+
+      include_examples "output_to_stream", :stderr, :to_stderr, Module.new {
+        def print_to_stream(msg)
+          STDERR.print(msg)
+        end
+      }
+
     end
 
     RSpec.describe "output.to_stdout matcher" do


### PR DESCRIPTION
An expectation of the form

```ruby
expect { ... }.to output.to_stderr
```

will work if anything is written to `$stderr` during the execution of the
block, but not if anything is written to `STDERR`. I encountered this
during working on a project and found the behaviour to be confusing.

Ideally both would work.rspec-expectations